### PR TITLE
Fix negative values in ROI point text parsing

### DIFF
--- a/scimap/helpers/_add_roi_omero.py
+++ b/scimap/helpers/_add_roi_omero.py
@@ -88,7 +88,7 @@ Example:
     
     def parse_roi_points(all_points):
         return np.array(
-            re.findall(r'\d+\.?\d+', all_points), dtype=float
+            re.findall(r'-?\d+\.?\d+', all_points), dtype=float
         ).reshape(-1, 2)
 
     def ellipse_points_to_patch(


### PR DESCRIPTION
Current regular expression assumes ROI points have coordinates >= 0, adding `-?` in the regex to allow negative values in ROI coordinates.