### PR TITLE
chore: update Dockerfile to reduce the image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.8
 
-RUN pip install scimap --upgrade
+RUN pip install --no-cache-dir scimap --upgrade
 
 COPY . /app/


### PR DESCRIPTION
Hi there,

I've made a small improvement to the Dockerfile that I think could help optimize the image size.

The change I made:
* I added the `--no-cache-dir` to the `pip` command to disable the package cache.


Impact on the image size:
* Image size before repair: 2.15 GB
* Image size after repair: 1.85 GB
* Difference: 307.74 MB (13.96%)

I hope that you will find these changes useful to you. Let me know if you have any questions or concerns.

Thanks,