### PR TITLE
Add spatial obsm to adata on MCMICRO loading

### DIFF
--- a/scimap/preprocessing/_mcmicro_to_scimap.py
+++ b/scimap/preprocessing/_mcmicro_to_scimap.py
@@ -165,7 +165,8 @@ adata = sm.pp.mcmicro_to_scimap (feature_table_path, drop_markers= ['CD21', 'ACT
     # Create an anndata object
     adata = ad.AnnData(entire_data)
     adata.obs = meta
-    adata.uns['all_markers'] = markers
+    adata.uns['all_markers'] = markers                       
+    adata.obsm['spatial'] = adata.obs[['X_centroid','Y_centroid']].to_numpy()
 
     # Add log data
     if log is True:


### PR DESCRIPTION
This PR adds the `spatial` OBSM to the data object created by the `sm.pp.mcmicro_to_scimap` function, pulling coordinates from `X_centroid` and `Y_centroid`.

This allows for `scanpy` visualizations such as `sc.pl.embedding(adata, basis = 'spatial', color = 'leiden')` to be run natively.

![image](https://github.com/labsyspharm/scimap/assets/14945787/89139934-3dbd-41a4-8dcf-70154f646639)
