### PR TITLE
Fixed str dtype for Unknown cells, Closes #107

### DIFF
--- a/scimap/tools/phenotype_cells.py
+++ b/scimap/tools/phenotype_cells.py
@@ -309,7 +309,7 @@ Example:
                 fail = list(x.loc[x['val'] < x['val'].sum() * pheno_threshold_percent/100].index)
             if pheno_threshold_abs is not None:
                 fail = list(x.loc[x['val'] < pheno_threshold_abs].index)
-            d[label] = d[label].replace(dict(zip(fail, np.repeat('Unknown',len(fail)))))
+            d[label] = d[label].replace(dict(zip(fail, ['Unknown'] * len(fail) )))
             # Return
             return d
 


### PR DESCRIPTION
This PR fixes the issue in ```sm.tl.phenotype_cells``` where Unknows cells get a dtype of ```np.str_``` which is inconsistent with other phenotype labels having a dtype of ```str``` which results in an error in sklearn due to mismatched dtypes. 