### PR TITLE
fix subset bug in addROI_image.py

### DIFF
--- a/scimap/plotting/addROI_image.py
+++ b/scimap/plotting/addROI_image.py
@@ -160,7 +160,7 @@ def addROI_image(
         if isinstance(subset, str):
             subset = [subset]
         # subset data
-        sub_data = data[data['imageid'].isin(subset)]
+        sub_data = data[data[imageid].isin(subset)]
     else:
         sub_data = data
 


### PR DESCRIPTION
Hey, I encountered a potential bug in while subsetting using addROI_image.py

The following line always defaulted to "imageid" and not the given variable when subsetting.
```python
sm.addROI_image(image_path, my_adata, imageid="ImageID", subset="my_image1")
```

This pull request fixed atleast my issue using `Python 3.9`